### PR TITLE
Updated code and instructions for the new b2clogin.com redirect URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ We have deployed this API to Azure to allow testing without running it locally. 
 The `/hello` endpoint in this sample is protected so an authorized request to it requires an access token in the header. 
 You can make authorized requests to this web API using an [iOS App](https://github.com/Azure-Samples/active-directory-b2c-ios-swift-native-msal) or [Android App](https://github.com/Azure-Samples/active-directory-b2c-android-native-msal). Make sure to update the app configs if you want it to point to your local hello api. 
 
+- *IMPORTANT*: In the past, `login.microsoftonline.com` was used for the redirect URL, now you should be using `b2clogin.com`. For more information on changing redirect URL's [see here](https://docs.microsoft.com/en-us/azure/active-directory-b2c/b2clogin).
+
 Alternatively, you can [register your own app](https://apps.dev.microsoft.com) and point to this web API.
 
-Customize your user experience further by supporting more identity providers.  Checkout the docs belows to learn how to add additional providers: 
+Customize your user experience further by supporting more identity providers.  Checkout the docs below to learn how to add additional providers: 
 
 [Microsoft](https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-setup-msa-app)
 

--- a/index.js
+++ b/index.js
@@ -10,12 +10,12 @@ var BearerStrategy = require('passport-azure-ad').BearerStrategy;
 
 // TODO: Update the first 3 variables
 var tenantID = "fabrikamb2c.onmicrosoft.com";
-var tenantRedirectUrl = "login.microsoftonline.com";
+var B2CHostname = "login.microsoftonline.com";
 var clientID = "25eef6e4-c905-4a07-8eb4-0d08d5df8b3f";
 var policyName = "B2C_1_SUSI";
 
 var options = {
-    identityMetadata: "https://" + tenantRedirectUrl + "/tfp/" + tenantID + "/v2.0/.well-known/openid-configuration/",
+    identityMetadata: "https://" + B2CHostname + "/tfp/" + tenantID + "/v2.0/.well-known/openid-configuration/",
     clientID: clientID,
     policyName: policyName,
     isB2C: true,

--- a/index.js
+++ b/index.js
@@ -10,11 +10,12 @@ var BearerStrategy = require('passport-azure-ad').BearerStrategy;
 
 // TODO: Update the first 3 variables
 var tenantID = "fabrikamb2c.onmicrosoft.com";
+var tenantRedirectUrl = "login.microsoftonline.com";
 var clientID = "25eef6e4-c905-4a07-8eb4-0d08d5df8b3f";
 var policyName = "B2C_1_SUSI";
 
 var options = {
-    identityMetadata: "https://login.microsoftonline.com/" + tenantID + "/v2.0/.well-known/openid-configuration/",
+    identityMetadata: "https://" + tenantRedirectUrl + "/tfp/" + tenantID + "/v2.0/.well-known/openid-configuration/",
     clientID: clientID,
     policyName: policyName,
     isB2C: true,


### PR DESCRIPTION
The previous instructions led to incompatibilities with the Xamarin B2C project. The end result was the app not properly authenticating users registered with external identity providers.